### PR TITLE
Add NVMe count check and corresponding unit tests

### DIFF
--- a/customTests/azure_nvme_count.nhc
+++ b/customTests/azure_nvme_count.nhc
@@ -2,10 +2,18 @@
 
 source /etc/nhc/scripts/azure_common.nhc
 
+function get_device_count() {
+      DIR="$1"
+
+      nvme_count=$(find "$DIR" -maxdepth 1 | grep -cE '/dev/nvme[0-9]+n1$')
+
+      echo $nvme_count
+}
+
 function check_nvme_count() {
    EXPECTED_NUM_NVME="$1"
 
-   nvme_count=$(find /dev -maxdepth 1 -type b | grep -cE '/dev/nvme[0-9]+n1$')
+   nvme_count=$(get_device_count /dev)
 
    if [ -z "$EXPECTED_NUM_NVME" ]; then
       die 1 -e "$FUNCNAME: No expected value provided for the number of NVMEs. NVME count found: $nvme_count. FaultCode: NHCNA"

--- a/test/unit-tests/nhc-hardware-test.sh
+++ b/test/unit-tests/nhc-hardware-test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+source $AZ_NHC_ROOT/customTests/azure_common.nhc
+source $AZ_NHC_ROOT/test/unit-tests/nhc-test-common.sh
+
+hardware_test=( "azure_nvme_count.nhc" )
+
+for check in "${hardware_test[@]}" ; do
+    source $AZ_NHC_ROOT/customTests/$check
+done
+
+create_mock_nvme_devices() {
+    DIR="$1"
+    local count=$2
+
+    mkdir -p "$DIR/dev"
+
+    for ((i=0; i<count; i++)); do
+        # Create block device files (touch creates regular files, but for testing purposes this works)
+        touch "$DIR/dev/nvme${i}n1"
+    done
+}
+
+@test "Empty temp directory" {
+    TEST_DEV_DIR=$(mktemp -d)
+
+    result=$(get_device_count "$TEST_DEV_DIR")
+    [ "$result" == "0" ]
+
+    rm -rf "$TEST_DEV_DIR"
+}
+
+@test "Temp Directory with fake devices" {
+    TEST_DEV_DIR=$(mktemp -d)
+    create_mock_nvme_devices $TEST_DEV_DIR 3
+
+    result=$(get_device_count "$TEST_DEV_DIR/dev")
+    [ "$result" == "3" ]
+
+    rm -rf "$TEST_DEV_DIR"
+}
+
+@test "Check NVMe count with no expected value" {
+    TEST_DEV_DIR=$(mktemp -d)
+    create_mock_nvme_devices $TEST_DEV_DIR 2
+
+    run check_nvme_count
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"No expected value provided"* ]]
+
+    rm -rf "$TEST_DEV_DIR"
+}

--- a/test/unit-tests/run_tests.sh
+++ b/test/unit-tests/run_tests.sh
@@ -57,6 +57,9 @@ else
     unit_test_status=$?
 fi
 
+# Other hardware unit tests
+sudo docker exec -it aznhc bash -c "bats --pretty /azure-nhc/test/unit-tests/nhc-hardware-test.sh"
+
 sudo docker container stop aznhc
 
 exit $((unit_test_status || integration_test_status))


### PR DESCRIPTION
- Refactor NVMe count retrieval into a separate function.
- Implement unit tests for NVMe count checking, including scenarios for empty directories and expected value checks.
- Update test runner to include the new hardware unit tests.